### PR TITLE
Support emojis on desc

### DIFF
--- a/util.sh
+++ b/util.sh
@@ -21,7 +21,7 @@ readonly timeout=$(if [ "$(uname)" == "Darwin" ]; then echo "1"; else echo "0.1"
 
 function desc() {
     maybe_first_prompt
-    echo "$blue# $@$reset"
+    echo -e "$blue# $@$reset"
     prompt
 }
 


### PR DESCRIPTION
Hi Tim, I liked these scripts and I was using them as base for a demo of my own. I ended up adding the "-e" flag to the echo on desc() so I can print emojis.

I don't know if you want (very simple) PRs for this or not. But I thought it is better to contribute back, it is completely fine if you don't want to take PRs for this :)

The other thing I ended up doing for my demos is adding a "desc_type", that just adds the comment typing them slowly instead of instantly as "desc" does. You can see my branch [here][branch], just in case.

[branch]: https://github.com/rata/micro-demos/commits/master

Below is the commit msg of the commit in this PR.

---

With this commit, you can print an emoji using its unicode, like:

	# tada emoji
	desc "\U1F389"