### PR TITLE
Small improvements: Add desc_type() and tune demo speed

### DIFF
--- a/util.sh
+++ b/util.sh
@@ -25,6 +25,17 @@ function desc() {
     prompt
 }
 
+function desc_type() {
+    maybe_first_prompt
+    rate=25
+    if [ -n "$DEMO_RUN_FAST" ]; then
+      rate=1000
+    fi
+    echo -e "$blue# $@$reset" | pv -qL $rate
+
+    prompt
+}
+
 function prompt() {
     echo -n "$yellow\$ $reset"
 }

--- a/util.sh
+++ b/util.sh
@@ -31,6 +31,9 @@ function desc_type() {
     if [ -n "$DEMO_RUN_FAST" ]; then
       rate=1000
     fi
+    if [ -n "$DEMO_RUN_SPEED" ]; then
+      rate=$DEMO_RUN_SPEED
+    fi
     echo -e "$blue# $@$reset" | pv -qL $rate
 
     prompt
@@ -57,6 +60,9 @@ function run() {
     rate=25
     if [ -n "$DEMO_RUN_FAST" ]; then
       rate=1000
+    fi
+    if [ -n "$DEMO_RUN_SPEED" ]; then
+      rate=$DEMO_RUN_SPEED
     fi
     echo "$green$1$reset" | pv -qL $rate
     if [ -n "$DEMO_RUN_FAST" ]; then


### PR DESCRIPTION
This adds (a) a desc_type function, that it prints a comment, like desc, but types it. It is useful for long comments that the user can't just read quickly, (b) a var DEMO_RUN_SPEED to tune the speed of different parts of the demos, as with long demos where you do something several times (like with or without user namespaces), it can get boring if we don't speed it up a little.

These are the patches I needed to create this video: https://www.youtube.com/watch?v=07y5bl5UDdA

I'll try to submit another PR with simplifications on the run function, because after running the script several times, the /tmp dir is full of lot of different directories, one for each command we run.

cc @thockin 

