### PR TITLE
utils.sh: Remove the tmp output file

### DIFF
--- a/util.sh
+++ b/util.sh
@@ -60,6 +60,7 @@ function run() {
       read -s
     fi
     DEMO_RUN_STDOUT="$(tail -n +2 $OFILE | sed 's/\r//g')"
+    rm $OFILE
     return $r
 }
 

--- a/util.sh
+++ b/util.sh
@@ -51,7 +51,7 @@ function run() {
     if [ -n "$DEMO_RUN_FAST" ]; then
       sleep 0.5
     fi
-    OFILE="$(mktemp -t $(basename $0).XXXXXX)"
+    OFILE="$(mktemp)"
     script -eq -c "$1" -f "$OFILE"
     r=$?
     read -d '' -t "${timeout}" -n 10000 # clear stdin

--- a/util.sh
+++ b/util.sh
@@ -59,7 +59,7 @@ function run() {
     if [ -z "$DEMO_AUTO_RUN" ]; then
       read -s
     fi
-    DEMO_RUN_STDOUT="$(tail -n +2 $OFILE | sed 's/\r//g')"
+    DEMO_RUN_STDOUT="$(tail -n +2 $OFILE | head -n -2 | sed 's/\r//g')"
     rm $OFILE
     return $r
 }


### PR DESCRIPTION
When running a command with run(), we keep the output in a tmp file in /tmp. When a demo runs a lot of commands and you run it several times to fix a thing here and there, it will create a million of tmp files that we don't really need.

This PR just removes the file after we used it.

While I'm there, I've changed the mktemp invocation to not use "-t" that is deprecated and remove the lines added by "script" at the end of the file too, when saving it into $DEMO_RUN_STDOUT.

I've also tried to get rid of script completely and just use something like: `DEMO_RUN_STDOUT=$(eval "$*" 2>&1); r=$?`. This works fine, but the only issue is that we need to print the output afterwards (as it is stored in that variable), and then the downside is that if the command takes long to run, you don't see anything and then you see it all.

So for long commands it might seem like nothing is happening and that is not nice for demos. But the output is usable in most interactive commands that I tried, so that would be a bonus of that approach.

But let's keep the PR simple for now. Let's just delete the file, that is all we really need for now.

If I need it, in the future I might look into options to add another run function, so commands are printed with colors (like ls -l, but it is not trivial and more dependencies might be needed). But for now just using the command with the explicit option to print colors is enough for me.